### PR TITLE
Add minimal support for keepnick

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,13 @@
 ---
 irc:
   # The hostname or IP address of the IRC server.
-  host: irc.example.com
+  host: irc.rwx.im
   # The port number of the IRC server.
   port: 6697
   # Use a secure connection.
   tls: true
   # The nickname used by the bot.
-  nick: chad
+  nick: chud
   # The username used by the bot.
   username: chad
   # The version response to CTCP VERSION requests.
@@ -17,6 +17,9 @@ irc:
     - "#chad"
   # List of nicknames to ignore messages from.
   ignored_nicks: []
+  # Whether to automatically change nickname to the configured one if it wasn't
+  # available during registration, and the bot sees it become available.
+  keepnick: true
 
 # Configuration for the GPT completion requests.
 # Reference: https://beta.openai.com/docs/api-reference/completions

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,16 +51,14 @@ module.exports = async (argv) => {
     logger.info(
       `Nick \`${event.nick}' is already in use - switching to \`${newNick}'`
     );
-    ircConfig.nick = newNick;
+
     client.changeNick(newNick);
   });
 
   client.on("registered", function (event) {
     logger.info("Connected and registered with nick `%s'", event.nick);
 
-    ircConfig.nick = event.nick;
-
-    HIGHLIGHTED_MESSAGE = new RegExp(`^${ircConfig.nick}[,:] (?<msg>.*)`);
+    HIGHLIGHTED_MESSAGE = new RegExp(`^${event.nick}[,:] (?<msg>.*)`);
 
     for (const channel of ircConfig.channels) {
       logger.info(`Joining channel \`${channel}'`);
@@ -157,6 +155,37 @@ module.exports = async (argv) => {
             `${event.nick}: OpenAI error: ${error.message}`
           );
         });
+    }
+  });
+
+  client.on("quit", function (event) {
+    if (
+      ircConfig.keepnick &&
+      client.user.nick != ircConfig.nick &&
+      event.nick == ircConfig.nick
+    ) {
+      // The user with our preferred nickname just quit, let's take it!
+      logger.info(
+        "`%s' just quit - trying to take over the nickname!",
+        event.nick
+      );
+      client.changeNick(ircConfig.nick);
+    }
+  });
+
+  client.on("nick", function (event) {
+    if (
+      ircConfig.keepnick &&
+      client.user.nick != ircConfig.nick &&
+      event.nick == ircConfig.nick
+    ) {
+      // The user with our preferred nickname just changed name, let's take it!
+      logger.info(
+        "`%s' just changed nickname to `%s' - trying to take over the old nickname!",
+        event.nick,
+        event.new_nick
+      );
+      client.changeNick(ircConfig.nick);
     }
   });
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,6 +33,11 @@ class IrcConfig {
   nick = DEFAULT_NICKNAME;
 
   /**
+   * Whether to change nickname to the configured one as soon as it becomes available.
+   */
+  keepnick = true;
+
+  /**
    * The username to register. Defaults to the nickname.
    */
   username = this.nick;


### PR DESCRIPTION
This implements partial support for #11.

It does not include a periodic timer that checks `ISON` to see if the nickname is available.

When a user with the wanted nickname quits or changes nickname, chadgpt will immediately try to take it over.