### PR TITLE
Add support for ignoring wildcard nicks

### DIFF
--- a/lib/__tests__/cli.test.js
+++ b/lib/__tests__/cli.test.js
@@ -1,0 +1,9 @@
+const cli = require("../cli.js");
+
+describe("cli", () => {
+  it("should fail when using invalid config path", () => {
+    const argv = ["node", "chadgpt", "-c", "invalidconfigfile.yaml"];
+
+    expect(async () => await cli(argv)).rejects.toThrow();
+  });
+});

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@ const { program } = require("commander");
 const OpenAI = require("openai");
 const IRC = require("irc-framework");
 const Mustache = require("mustache");
+const wildcard = require("wildcard");
 
 const package_version = require("../package.json").version;
 const { Config } = require("./config.js");
@@ -79,8 +80,10 @@ module.exports = async (argv) => {
   });
 
   client.on("privmsg", function (event) {
+    const ignored_nicks = ircConfig["ignored_nicks"];
+
     // Skip responding to ignored nicknames.
-    if (ircConfig["ignored_nicks"].includes(event.nick)) {
+    if (ignored_nicks.some((nick) => wildcard(nick, event.nick))) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "marked": "^4.3.0",
     "mustache": "^4.2.0",
     "openai": "^3.3.0",
+    "wildcard": "^2.0.1",
     "winston": "^3.11.0",
     "yaml": "^2.3.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   openai:
     specifier: ^3.3.0
     version: 3.3.0
+  wildcard:
+    specifier: ^2.0.1
+    version: 2.0.1
   winston:
     specifier: ^3.11.0
     version: 3.11.0
@@ -3114,6 +3117,10 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
+  /wildcard@2.0.1:
+    resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
+    dev: false
 
   /winston-transport@4.6.0:
     resolution: {integrity: sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==}


### PR DESCRIPTION
This makes it possible to ignore nicks using wildcards:

```yaml
irc:
  ignored_nicks:
  - 'user*'
```