### PR TITLE
Add special case for handling single truncated lines.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -145,11 +145,12 @@ module.exports = async (argv) => {
             let lines = text.split("\n");
             const maxLines = 7;
 
-            lines.slice(0, maxLines).forEach((line) => {
+	          let specialCase = lines.length == maxLines + 1;
+            lines.slice(0, maxLines + specialCase).forEach((line) => {
               client.say(event.target, `${event.nick}: ${line}`);
             });
 
-            if (lines.length > maxLines) {
+            if (!specialCase && lines.length > maxLines) {
               client.say(
                 event.target,
                 `${event.nick}: .. (${


### PR DESCRIPTION
Just output the single truncated line, rather than spending the extra line on the "1 line was truncated" message.